### PR TITLE
Adiciona suporte a Nuconta

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+YNAB_EMAIL=e@mail.com
+YNAB_PASSWORD=ynab_password
+YNAB_BUDGET=budget_name_on_ynab
+NUBANK_TOKEN=nubank_token
+NUBANK_CERT=nubank_cert_encoded_in_base64
+NUBANK_CARD_ACCOUNT=Nubank
+NUBANK_NUCONTA_ACCOUNT=Nuconta
+STARTING_POINT=2021-01-01
+

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ As credenciais são configuradas por variáveis de ambiente. São elas:
 - **YNAB_BUDGET**: Nome do seu orçamento
 - **NUBANK_TOKEN**: Seu refresh token [gerado pelo pynubank](https://github.com/andreroggeri/pynubank/blob/master/examples/login-refresh-token.md)
 - **NUBANK_CERT**: Seu certificado do Nubank [gerado pelo pynubank](https://github.com/andreroggeri/pynubank/blob/master/examples/login-certificate.md) codificado em base64 (Para gerar no linux: `cat caminho/do/cert.p12 | base64`)
+- **NUBANK_CARD_ACCOUNT**: Nome da conta do cartão Nubank no YNAB
+- **NUBANK_NUCONTA_ACCOUNT**: Nome da conta Nuconta no YNAB
 - **STARTING_POINT**: Data que será considerada para importar os dados do Nubank para o nYNAB,
 todas as transações anteriores a essa data serão ignoradas. Idealmente essa data deve ser a data da 
 ultima transação que você cadastrou no nYNAB, isso serve para que o App não duplique as transações que você já importou. 

--- a/nubank_sync_ynab/sync.py
+++ b/nubank_sync_ynab/sync.py
@@ -26,7 +26,11 @@ YNAB_PASSWORD = os.getenv('YNAB_PASSWORD')
 YNAB_BUDGET = os.getenv('YNAB_BUDGET')
 NUBANK_TOKEN = os.getenv('NUBANK_TOKEN')
 NUBANK_CERT = os.getenv('NUBANK_CERT')
+NUBANK_CARD_ACCOUNT = os.getenv('NUBANK_CARD_ACCOUNT')
+NUBANK_NUCONTA_ACCOUNT = os.getenv('NUBANK_NUCONTA_ACCOUNT')
 STARTING_POINT = datetime.datetime.strptime(os.getenv('STARTING_POINT'), '%Y-%m-%d').date()
+
+IN_EVENT = ['TransferInEvent', 'TransferOutReversalEvent']
 
 if __name__ == '__main__':
     with open('cert.p12', 'wb') as f:
@@ -38,16 +42,40 @@ if __name__ == '__main__':
     ynab = YNAB(YNAB_EMAIL, YNAB_PASSWORD, YNAB_BUDGET)
     nu = Nubank()
     nu.authenticate_with_refresh_token(NUBANK_TOKEN, './cert.p12')
+
     transactions = filter_transactions(nu.get_card_statements(), STARTING_POINT)
 
-    print(f'Found {len(transactions)} transactions')
+    print(f'Found {len(transactions)} card transactions')
     for transaction in transactions:
         ynab.add_transaction(
             payee=transaction['description'],
             date=parse_transaction_date(transaction),
             value=-int(transaction['amount']) / 100,
             id=transaction['id'],
-            subcategory=transaction['category'].capitalize()
+            subcategory=transaction['category'].capitalize(),
+            account=NUBANK_CARD_ACCOUNT
+        )
+    
+    account_transactions = filter_transactions(nu.get_account_statements(), STARTING_POINT)
+
+    print(f'Found {len(account_transactions)} account transactions')
+    for transaction in account_transactions:
+        print(transaction)
+        payee = transaction['title']
+        if not transaction.get('__typename') in IN_EVENT:
+            transaction['amount'] = transaction['amount'] * -1
+            if 'destinationAccount' in transaction:
+                payee = transaction['destinationAccount']['name']
+        else:
+            if 'originAccount' in transaction:
+                payee = transaction['originAccount']['name']
+        ynab.add_transaction(
+            payee=payee,
+            date=parse_transaction_date(transaction),
+            value=transaction['amount'],
+            id=transaction['id'],
+            subcategory='',
+            account=NUBANK_NUCONTA_ACCOUNT
         )
 
     ynab.sync()

--- a/nubank_sync_ynab/util.py
+++ b/nubank_sync_ynab/util.py
@@ -19,4 +19,8 @@ def filter_transactions(transactions, starting_date, days=30):
 
 
 def parse_transaction_date(transaction) -> datetime.date:
-    return datetime.datetime.strptime(transaction['time'][:10], "%Y-%m-%d").date()
+    if 'time' in transaction:
+        date_key = 'time'
+    else:
+        date_key = 'postDate'
+    return datetime.datetime.strptime(transaction[date_key][:10], "%Y-%m-%d").date()

--- a/nubank_sync_ynab/ynab.py
+++ b/nubank_sync_ynab/ynab.py
@@ -18,16 +18,15 @@ class YNAB:
             sync=sync
         )
         self.delta = 0
-        self.account = self.get_nubank_account()
 
-    def get_nubank_account(self):
+    def get_account(self, account_name):
         try:
-            logging.info('Searching for Nubank account')
-            return next(acc for acc in self.client.budget.be_accounts if acc.account_name == 'Nubank')
+            logging.info('Searching for ' + account_name + ' account')
+            return next(acc for acc in self.client.budget.be_accounts if acc.account_name == account_name)
         except StopIteration:
-            logging.info('Nubank account not found, creating a new one')
+            logging.info(account_name + ' account not found, creating a new one')
             account = Account()
-            account.account_name = 'Nubank'
+            account.account_name = account_name
             self.client.budget.be_accounts.append(account)
             self.delta += 1
             return account
@@ -63,6 +62,7 @@ class YNAB:
         logging.info('Adding transaction')
         payee = self.get_payee(kwargs['payee'])
         subcategory = self.get_subcategory(kwargs['subcategory'])
+        account = self.get_account(kwargs['account'])
 
         if not self.has_matching_transaction(kwargs['id']):
             logging.info('Creating transaction')
@@ -75,7 +75,7 @@ class YNAB:
             transaction.imported_date = datetime.datetime.now().date()
             transaction.source = "Imported"
             transaction.amount = kwargs['value']
-            transaction.entities_account_id = self.account.id
+            transaction.entities_account_id = account.id
             self.client.budget.be_transactions.append(transaction)
             self.delta += 1
 


### PR DESCRIPTION
Este PR adiciona a sincronização de transações da Nuconta, resolvendo assim parcialmente a issue #10. A sincronização de rendimentos não está implementada.

Obs: a versão atual da pynubank não fornece as transferências enviadas por Pix. Há um PR que implementa isso https://github.com/andreroggeri/pynubank/pull/223. Se quiser utilizar essa versão, faça o seguinte:
```
pip uninstall pynubank
pip install git+https://github.com/gutobenn/pynubank@pix_events
```